### PR TITLE
feat: allow users to select location

### DIFF
--- a/src/components/LocationModal.tsx
+++ b/src/components/LocationModal.tsx
@@ -1,0 +1,33 @@
+import { useLocation, LocationKey } from "@/context/LocationContext";
+
+export default function LocationModal({ onClose }: { onClose: () => void }) {
+  const { setLocation, locations } = useLocation();
+
+  const choose = (loc: LocationKey) => {
+    setLocation(loc);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white p-6 rounded shadow-md max-w-sm w-full">
+        <h2 className="text-xl font-semibold mb-4">Choose Location</h2>
+        {Object.entries(locations).map(([key, info]) => (
+          <div key={key} className="mb-4">
+            <button
+              className="text-primary font-semibold underline"
+              onClick={() => choose(key as LocationKey)}
+            >
+              {info.name}
+            </button>
+            <div className="text-sm mt-1">
+              {info.phones.map((p) => (
+                <p key={p}>{p}</p>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,17 +1,26 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { icons } from "@/utils/icons";
 import { type Language, siteSetting } from "@/utils/site";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useLocation } from "@/context/LocationContext";
+import LocationModal from "./LocationModal";
 
 export default function Navbar({ id }: { id : string}) {
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [locationModal, setLocationModal] = useState(false);
   const router = useRouter();
+  const { location, locations } = useLocation();
 
   const t = router.locale as Language;
+
+  useEffect(() => {
+    if (!location) {
+      setLocationModal(true);
+    }
+  }, [location]);
 
   return (
     <nav id={id} className={`z-50 w-full bg-[#ffffff] bg-cover flex justify-center ${menuOpen ? "sticky lg:relative" : ""} top-0 shadow-md shadow-primary`}>
@@ -21,23 +30,101 @@ export default function Navbar({ id }: { id : string}) {
           <h1 className="hidden lg:flex font-semibold md:text-[23px] lg:text-[32px]">Buddha Nepal</h1>
         </div>
         <div className="hidden items-center md:flex text-md lg:text-lg gap-7 font-semibold text-primary">
-          {siteSetting.getHeaderLinks().map(item => <Link locale={router.locale} key={item.en} href={item.href} className={`${router.asPath === item.href ? "border-b-2 border-primary" : ""}`}>{item[t]}</Link>)}
+          {siteSetting.getHeaderLinks().map(item => (
+            <Link
+              locale={router.locale}
+              key={item.en}
+              href={item.href}
+              className={`${router.asPath === item.href ? "border-b-2 border-primary" : ""}`}
+            >
+              {item[t]}
+            </Link>
+          ))}
+          <div
+            className="flex flex-col text-right text-xs cursor-pointer"
+            onClick={() => setLocationModal(true)}
+          >
+            <span>{location ? locations[location].name : "Select Location"}</span>
+            {location && (
+              <div className="flex gap-2">
+                {locations[location].phones.map((p) => (
+                  <a key={p} href={`tel:${p.replace(/\s+/g, "")}`}>{p}</a>
+                ))}
+              </div>
+            )}
+          </div>
           <div className="flex gap-2 [&>*]:p-1 ">
-            <Image src={icons.english} alt="english" onClick={() => router.push("", "", { locale: "en"})}  width={40} height={40} className={`rounded ${t === "en" ? "bg-primary" : ""}`} />
-            <Image src={icons.swedish} alt="swedish" onClick={() => router.push("", "", { locale: "se"})}  width={40} height={40} className={`rounded ${t === "se" ? "bg-primary" : ""}`} />
+            <Image
+              src={icons.english}
+              alt="english"
+              onClick={() => router.push("", "", { locale: "en" })}
+              width={40}
+              height={40}
+              className={`rounded ${t === "en" ? "bg-primary" : ""}`}
+            />
+            <Image
+              src={icons.swedish}
+              alt="swedish"
+              onClick={() => router.push("", "", { locale: "se" })}
+              width={40}
+              height={40}
+              className={`rounded ${t === "se" ? "bg-primary" : ""}`}
+            />
           </div>
         </div>
         <Image src={menuOpen ? icons.close : icons.menu} onClick={() => setMenuOpen(prev => !prev)} alt="menu" width={30} className="md:hidden cursor-pointer" />
       </div>
-      {menuOpen && <div className="z-30 md:hidden fixed h-screen w-screen bg-white top-0 left-0 grid place-content-center">
+      {menuOpen && (
+        <div className="z-30 md:hidden fixed h-screen w-screen bg-white top-0 left-0 grid place-content-center">
           <div className="flex flex-col items-center gap-7 font-semibold text-primary text-[25px]">
-            {siteSetting.getHeaderLinks().map(item => <Link key={item.en} href={item.href} onClick={() => setMenuOpen(false)} className={`${router.asPath === item.href ? "border-b-2 border-primary" : ""}`}>{item[t]}</Link>)}
+            {siteSetting.getHeaderLinks().map((item) => (
+              <Link
+                key={item.en}
+                href={item.href}
+                onClick={() => setMenuOpen(false)}
+                className={`${router.asPath === item.href ? "border-b-2 border-primary" : ""}`}
+              >
+                {item[t]}
+              </Link>
+            ))}
+            <div
+              className="text-center text-base cursor-pointer"
+              onClick={() => {
+                setLocationModal(true);
+                setMenuOpen(false);
+              }}
+            >
+              <p>{location ? locations[location].name : "Select Location"}</p>
+              {location && (
+                <>
+                  {locations[location].phones.map((p) => (
+                    <p key={p}>{p}</p>
+                  ))}
+                </>
+              )}
+            </div>
             <div className="flex gap-2 [&>*]:p-1 ">
-            <Image src={icons.english} alt="english" onClick={() => router.push("", "", { locale: "en"})}  width={40} height={40} className={`rounded ${t === "en" ? "bg-primary" : ""}`} />
-            <Image src={icons.swedish} alt="swedish" onClick={() => router.push("", "", { locale: "se"})}  width={40} height={40} className={`rounded ${t === "se" ? "bg-primary" : ""}`} />
+              <Image
+                src={icons.english}
+                alt="english"
+                onClick={() => router.push("", "", { locale: "en" })}
+                width={40}
+                height={40}
+                className={`rounded ${t === "en" ? "bg-primary" : ""}`}
+              />
+              <Image
+                src={icons.swedish}
+                alt="swedish"
+                onClick={() => router.push("", "", { locale: "se" })}
+                width={40}
+                height={40}
+                className={`rounded ${t === "se" ? "bg-primary" : ""}`}
+              />
+            </div>
           </div>
-          </div>
-        </div>}
+        </div>
+      )}
+      {locationModal && <LocationModal onClose={() => setLocationModal(false)} />}
     </nav>
   )
 }

--- a/src/context/LocationContext.tsx
+++ b/src/context/LocationContext.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export type LocationKey = "arsta" | "haga";
+
+interface LocationInfo {
+  name: string;
+  phones: string[];
+}
+
+const locations: Record<LocationKey, LocationInfo> = {
+  arsta: {
+    name: "ÅRSTAVÄGEN 39, 120 52 Årsta",
+    phones: ["08-684 271 90", "0760-35 37 99"],
+  },
+  haga: {
+    name: "Buddha Haga",
+    phones: ["08-684 271 90", "0760-35 37 99"],
+  },
+};
+
+interface LocationContextProps {
+  location: LocationKey | null;
+  setLocation: (loc: LocationKey) => void;
+  locations: typeof locations;
+}
+
+const LocationContext = createContext<LocationContextProps>({
+  location: null,
+  setLocation: () => {},
+  locations,
+});
+
+export const LocationProvider = ({ children }: { children: ReactNode }) => {
+  const [location, setLocationState] = useState<LocationKey | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("location") as LocationKey | null;
+      if (stored === "arsta" || stored === "haga") {
+        setLocationState(stored);
+      }
+    }
+  }, []);
+
+  const setLocation = (loc: LocationKey) => {
+    setLocationState(loc);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("location", loc);
+    }
+  };
+
+  return (
+    <LocationContext.Provider value={{ location, setLocation, locations }}>
+      {children}
+    </LocationContext.Provider>
+  );
+};
+
+export const useLocation = () => useContext(LocationContext);
+
+export const locationData = locations;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,14 +4,16 @@ import Image from "next/image";
 import restaurantMovingImg from "@/assets/restaurant-moving.avif";
 import "@/styles/globals.css";
 import Layout from "@/components/Layout";
+import { LocationProvider } from "@/context/LocationContext";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <main className="flex flex-col min-h-screen">
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-      {/* <div className="h-screen w-full bg-purple-200 flex flex-col items-center  p-24">
+    <LocationProvider>
+      <main className="flex flex-col min-h-screen">
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+        {/* <div className="h-screen w-full bg-purple-200 flex flex-col items-center  p-24">
         <div className="flex flex-row">
         <Image className="h-36 w-36" src={icons.announcement} alt=""  />
         <div className="flex flex-col ml-8 leading-10">
@@ -21,6 +23,7 @@ export default function App({ Component, pageProps }: AppProps) {
         </div>
         </div>
       </div> */}
-    </main>
+      </main>
+    </LocationProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add location context and modal for choosing between Årsta and Buddha Haga
- persist selection in localStorage and show chosen address with contacts in navbar
- wrap app with new LocationProvider

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc38ec4230832fb73b2cbe6afc1ebc