### PR TITLE
feat: update opening hours

### DIFF
--- a/src/pages/timings.tsx
+++ b/src/pages/timings.tsx
@@ -1,25 +1,27 @@
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { Language } from "@/utils/site";
+import { timings } from "@/utils/translations";
 
 export default function Timings() {
+  const router = useRouter();
+  const t = router.locale as Language;
+
   return (
     <main className="flex-1 flex">
       <Head>
-        <title>Buddha Nepal - Öppettider</title>
+        <title>{`Buddha Nepal - ${timings.opening_hours[t]}`}</title>
       </Head>
       <div className="w-full flex-1 flex justify-center">
         <div className="w-[350px] flex-1 md:w-[700px] h-full mb-[25px] lg:mb-[100px] lg:w-[1000px] xl:w-[1200px] flex items-center flex-col justify-start mt-[150px] gap-10">
-          <h1 className="text-4xl lg:text-5xl font-bold">ÖPPETTIDER</h1>
-          <h1 className="text-3xl lg:text-4xl font-bold">
-            MÅN-TORS: 11.00 - 21.00
+          <h1 className="text-4xl lg:text-5xl font-bold">
+            {timings.opening_hours[t]}
           </h1>
           <h1 className="text-3xl lg:text-4xl font-bold">
-            FREDAG: 11.00 - 22.00
+            {timings.weekdays[t]}
           </h1>
           <h1 className="text-3xl lg:text-4xl font-bold">
-            LÖRDAG: 15.00 - 22.00
-          </h1>
-          <h1 className="text-3xl lg:text-4xl font-bold">
-            SÖNDAG: 15.00 - 21.00
+            {timings.weekends[t]}
           </h1>
         </div>
       </div>

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -1788,6 +1788,21 @@ export const about_us = {
   },
 };
 
+export const timings = {
+  opening_hours: {
+    en: "OPENING HOURS",
+    se: "ÖPPETTIDER",
+  },
+  weekdays: {
+    en: "Mon - Fri 11:00 - 21:00",
+    se: "Mån - Fre 11:00 - 21:00",
+  },
+  weekends: {
+    en: "Sat - Sun 13:00 - 21:00",
+    se: "Lör - Sön 13:00 - 21:00",
+  },
+};
+
 export const messages = {
   information: {
     lunch: {


### PR DESCRIPTION
## Summary
- move opening hours strings into translations util
- localize timings page using centralized translations

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc37eff310832f92c9f279342b2a9c