### PR TITLE
feat: add contact page

### DIFF
--- a/public/foodora.svg
+++ b/public/foodora.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <rect width="200" height="40" fill="#d6004a"/>
+  <text x="10" y="27" font-family="Arial" font-size="24" fill="white">Foodora</text>
+</svg>

--- a/public/uber-eats.svg
+++ b/public/uber-eats.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <rect width="200" height="40" fill="#000000"/>
+  <text x="10" y="27" font-family="Arial" font-size="24" fill="#06c167">Uber Eats</text>
+</svg>

--- a/public/wolt.svg
+++ b/public/wolt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <rect width="200" height="40" fill="#009de0"/>
+  <text x="10" y="27" font-family="Arial" font-size="24" fill="white">Wolt</text>
+</svg>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,55 @@
+import Head from "next/head";
+import Image from "next/image";
+import { useRouter } from "next/router";
+import { contact } from "@/utils/translations";
+import { Language } from "@/utils/site";
+
+export default function Contact() {
+  const router = useRouter();
+  const t = router.locale as Language;
+
+  return (
+    <main className="flex-1 flex">
+      <Head>
+        <title>{`Buddha Nepal - ${contact.title[t]}`}</title>
+      </Head>
+      <div className="w-full flex-1 flex justify-center">
+        <div className="w-[350px] flex-1 md:w-[700px] h-full mb-[25px] lg:mb-[100px] lg:w-[1000px] xl:w-[1200px] flex items-center flex-col justify-start mt-[150px] gap-10">
+          <h1 className="text-4xl lg:text-5xl font-bold">{contact.title[t]}</h1>
+
+          <div className="flex flex-col gap-8 w-full text-center">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-2xl font-semibold">{contact.address_one[t]}</h2>
+              <p>{contact.opening_times[t]}</p>
+              <p>{contact.weekdays[t]}</p>
+              <p>{contact.weekends[t]}</p>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h2 className="text-2xl font-semibold">{contact.address_two[t]}</h2>
+              <p>{contact.opening_times[t]}</p>
+              <p>{contact.weekdays[t]}</p>
+              <p>{contact.weekends[t]}</p>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center gap-4 mt-4">
+            <h2 className="text-2xl font-semibold">{contact.order_call[t]}</h2>
+            <div className="flex flex-col">
+              <a href="tel:0868427190" className="underline">
+                {contact.phone_one[t]}
+              </a>
+              <a href="tel:0760353799" className="underline">
+                {contact.phone_two[t]}
+              </a>
+            </div>
+            <div className="flex items-center gap-4 mt-4">
+              <Image src="/foodora.svg" alt="Foodora" width={120} height={40} />
+              <Image src="/wolt.svg" alt="Wolt" width={120} height={40} />
+              <Image src="/uber-eats.svg" alt="Uber Eats" width={120} height={40} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -26,9 +26,9 @@ export const siteSetting = {
       //   href: "/catering",
       // },
       {
-        en: "Öppettider",
-        se: "Öppettider",
-        href: "/timings",
+        en: "Contact",
+        se: "Kontakt",
+        href: "/contact",
       },
       {
         en: "About Us",

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -1803,6 +1803,45 @@ export const timings = {
   },
 };
 
+export const contact = {
+  title: {
+    en: "Contact",
+    se: "Kontakt",
+  },
+  address_one: {
+    en: "Årstavägen 39, 120 52 Årsta",
+    se: "Årstavägen 39, 120 52 Årsta",
+  },
+  address_two: {
+    en: "Ynglingagatan 9, 113 47 Stockholm",
+    se: "Ynglingagatan 9, 113 47 Stockholm",
+  },
+  opening_times: {
+    en: "Opening times for this location:",
+    se: "Öppettider för denna plats:",
+  },
+  weekdays: {
+    en: "Mon - Fri : 11:00 - 21:00",
+    se: "Mån - Fre : 11:00 - 21:00",
+  },
+  weekends: {
+    en: "Sat - Sun : 13:00 - 21:00",
+    se: "Lör - Sön : 13:00 - 21:00",
+  },
+  order_call: {
+    en: "You can order by calling us on:",
+    se: "Du kan beställa genom att ringa oss på:",
+  },
+  phone_one: {
+    en: "08-684 271 90",
+    se: "08-684 271 90",
+  },
+  phone_two: {
+    en: "0760-35 37 99",
+    se: "0760-35 37 99",
+  },
+};
+
 export const messages = {
   information: {
     lunch: {


### PR DESCRIPTION
## Summary
- replace opening hours menu entry with new contact link
- add contact page with locations, phone ordering, and delivery logos
- include translations for contact details in English and Swedish

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a1fc848832fbf3b5076ef343b87