### PR TITLE
Revamp homepage dishes and disable Haga location

### DIFF
--- a/public/menu/caesar-salad.svg
+++ b/public/menu/caesar-salad.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#ec4899' />
+      <stop offset='100%' stop-color='#6366f1' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Caesar Salad</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Creamy dressing & crunch</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/chicken-burger.svg
+++ b/public/menu/chicken-burger.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#a855f7' />
+      <stop offset='100%' stop-color='#f97316' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Chicken Burger</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Stacked with house sauce</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/chicken-teriyaki.svg
+++ b/public/menu/chicken-teriyaki.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#6366f1' />
+      <stop offset='100%' stop-color='#0ea5e9' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Chicken Teriyaki</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Glazed umami shine</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/chicken-timur.svg
+++ b/public/menu/chicken-timur.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#facc15' />
+      <stop offset='100%' stop-color='#ef4444' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Chicken Timur</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Nepal pepper marinade</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/chilli-chicken.svg
+++ b/public/menu/chilli-chicken.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#ec4899' />
+      <stop offset='100%' stop-color='#6366f1' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Chilli Chicken</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Fiery wok-fried bites</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/choila.svg
+++ b/public/menu/choila.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#a855f7' />
+      <stop offset='100%' stop-color='#f97316' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Choila</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Smoky grilled delicacy</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/fried-rice.svg
+++ b/public/menu/fried-rice.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#6366f1' />
+      <stop offset='100%' stop-color='#0ea5e9' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Fried Rice</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Stir-fried jasmine grains</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/grilled-chicken-pommes.svg
+++ b/public/menu/grilled-chicken-pommes.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#22c55e' />
+      <stop offset='100%' stop-color='#14b8a6' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Grilled Chicken & Pommes</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Charred herbs & crisp fries</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/momos.svg
+++ b/public/menu/momos.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#22c55e' />
+      <stop offset='100%' stop-color='#14b8a6' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Momos</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Steamed Nepali dumplings</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/mustang-aloo.svg
+++ b/public/menu/mustang-aloo.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f97316' />
+      <stop offset='100%' stop-color='#ec4899' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Mustang Aaloo</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Smoked potatoes & spice</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/noodles-chicken-scampi.svg
+++ b/public/menu/noodles-chicken-scampi.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f97316' />
+      <stop offset='100%' stop-color='#ec4899' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Chicken & Scampi Noodles</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Wok-tossed ribbon noodles</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/samosa-tamarind-mango-mint.svg
+++ b/public/menu/samosa-tamarind-mango-mint.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f97316' />
+      <stop offset='100%' stop-color='#ec4899' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Samosa Chaat</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Tamarind & mango-mint chutneys</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/schnitzel.svg
+++ b/public/menu/schnitzel.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#facc15' />
+      <stop offset='100%' stop-color='#ef4444' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Schnitzel</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Crisp golden cutlet</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/public/menu/thukpa.svg
+++ b/public/menu/thukpa.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800' preserveAspectRatio='xMidYMid slice'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#6366f1' />
+      <stop offset='100%' stop-color='#0ea5e9' />
+    </linearGradient>
+    <filter id='noise'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix type='saturate' values='0.5'/>
+      <feBlend mode='multiply' in2='SourceGraphic'/>
+    </filter>
+  </defs>
+  <rect width='1200' height='800' fill='url(#grad)' />
+  <rect width='1200' height='800' fill='url(#grad)' opacity='0.35' filter='url(#noise)' />
+  <g fill='rgba(255,255,255,0.7)'>
+    <circle cx='150' cy='120' r='90' opacity='0.25'/>
+    <circle cx='1080' cy='690' r='130' opacity='0.18'/>
+    <circle cx='980' cy='120' r='110' opacity='0.12'/>
+  </g>
+  <text x='60' y='540' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='72' font-weight='600' letter-spacing='4'>Thukpa</text>
+  <text x='60' y='620' fill='rgba(255,255,255,0.85)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='36' font-weight='300'>Himalayan noodle soup</text>
+  <text x='60' y='700' fill='rgba(255,255,255,0.7)' font-family='"Poppins", "Helvetica Neue", sans-serif' font-size='28' font-weight='300'>BUDDHA Nepal • Crafted with seasonal ingredients</text>
+</svg>

--- a/src/components/Homepage.1.tsx
+++ b/src/components/Homepage.1.tsx
@@ -214,29 +214,37 @@ export default function Homepage() {
             {homepage.menu_description[t]}
           </h1>
         </div>
-        <div className="food-scroll w-full pb-2 flex flex-row gap-5 overflow-x-auto">
-          {homepage.dishes.map((item) => (
-            <div
+        <div className="food-scroll w-full pb-2 flex flex-row gap-6 overflow-x-auto snap-x snap-mandatory">
+          {homepage.dishes.map((item, index) => (
+            <article
               key={item.name.en}
-              className="food-banner rounded-md flex-none overflow-hidden w-[250px] h-[300px] md:w-[300px] md:h-[400px] flex flex-col bg-cover bg-center justify-between"
-              style={{ backgroundImage: `url(${item.source})` }}
+              className="relative group flex-none w-[260px] h-[360px] md:w-[300px] md:h-[420px] lg:w-[320px] rounded-3xl overflow-hidden shadow-xl shadow-black/10 bg-black/10 backdrop-blur-sm transition-transform duration-500 hover:-translate-y-2 snap-start"
             >
-              {/* {item.price !== null ? (
-                      <h1 className="bg-primary w-fit p-3 md:p-5 rounded-md font-bold">
-                        {item.price}kr
-                      </h1>
-                    ) : (
-                      <div />
-                    )} */}
-              {/* <div className="bg-primary py-3 px-2 flex flex-col">
-                      <h1 className="text-[20px] md:text-[25px] font-bold">
-                        {item.name[t]}
-                      </h1>
-                      <p className="text-[12px] md:text-[18px] food-description">
-                        {item.description[t]}
-                      </p>
-                    </div> */}
-            </div>
+              <Image
+                src={item.source}
+                alt={item.name.en}
+                fill
+                sizes="(max-width: 768px) 260px, (max-width: 1024px) 300px, 320px"
+                priority={index === 0}
+                className="object-cover transition-transform duration-700 ease-out group-hover:scale-105"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/30 to-black/10" />
+              <div className="relative z-10 flex h-full flex-col justify-end gap-4 p-6 text-left text-white">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-lg font-semibold uppercase tracking-wide">
+                    {item.name[t]}
+                  </h3>
+                  {item.price !== null && (
+                    <span className="rounded-full bg-white/20 px-3 py-1 text-sm font-semibold uppercase tracking-wide backdrop-blur-sm">
+                      {item.price} kr
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm leading-relaxed text-white/80">
+                  {item.description[t]}
+                </p>
+              </div>
+            </article>
           ))}
         </div>
       </div>

--- a/src/components/LocationSelect.tsx
+++ b/src/components/LocationSelect.tsx
@@ -20,11 +20,17 @@ export default function LocationSelect({ className = "", onChange }: { className
       <option value="" disabled>
         Select Location
       </option>
-      {Object.entries(locations).map(([key, info]) => (
-        <option key={key} value={key}>
-          {info.shortName}
-        </option>
-      ))}
+      {Object.entries(locations).map(([key, info]) => {
+        const label = info.isActive
+          ? info.shortName
+          : `${info.shortName} (Coming Soon)`;
+
+        return (
+          <option key={key} value={key} disabled={!info.isActive}>
+            {label}
+          </option>
+        );
+      })}
     </select>
   );
 }

--- a/src/context/LocationContext.tsx
+++ b/src/context/LocationContext.tsx
@@ -16,6 +16,8 @@ interface LocationInfo {
   phones: string[];
   /** Google Maps embed source URL */
   mapSrc: string;
+  /** Whether guests can actively select the location */
+  isActive: boolean;
 }
 
 const locations: Record<LocationKey, LocationInfo> = {
@@ -25,6 +27,7 @@ const locations: Record<LocationKey, LocationInfo> = {
     phones: ["08-684 271 90", "0760-35 37 99"],
     mapSrc:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2037.2104655923176!2d18.05061867705999!3d59.296042113684926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f7791cc0466d9%3A0xa844d6d5435f306a!2sBUDDHA%20Nepal!5e0!3m2!1sen!2sse!4v1757644635036!5m2!1sen!2sse",
+    isActive: true,
   },
   haga: {
     name: "BUDDHA Haga",
@@ -32,8 +35,13 @@ const locations: Record<LocationKey, LocationInfo> = {
     phones: ["08-684 271 90", "0760-35 37 99"],
     mapSrc:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4068.038657368876!2d18.04833100611805!3d59.34932516386402!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f9d724ef405ef%3A0xba83e55580836315!2sYnglingagatan%209%2C%20113%2047%20Stockholm!5e0!3m2!1sen!2sse!4v1757644789600!5m2!1sen!2sse",
+    isActive: false,
   },
 };
+
+const firstActiveLocation: LocationKey | null = (Object.keys(locations) as LocationKey[]).find(
+  (key) => locations[key].isActive,
+) ?? null;
 
 interface LocationContextProps {
   location: LocationKey | null;
@@ -48,18 +56,28 @@ const LocationContext = createContext<LocationContextProps>({
 });
 
 export const LocationProvider = ({ children }: { children: ReactNode }) => {
-  const [location, setLocationState] = useState<LocationKey | null>(null);
+  const [location, setLocationState] = useState<LocationKey | null>(firstActiveLocation);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const stored = localStorage.getItem("location") as LocationKey | null;
-      if (stored === "arsta" || stored === "haga") {
+      if (stored && locations[stored]?.isActive) {
         setLocationState(stored);
+        return;
+      }
+
+      if (stored) {
+        localStorage.removeItem("location");
       }
     }
+
   }, []);
 
   const setLocation = (loc: LocationKey) => {
+    if (!locations[loc]?.isActive) {
+      return;
+    }
+
     setLocationState(loc);
     if (typeof window !== "undefined") {
       localStorage.setItem("location", loc);

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -35,76 +35,172 @@ export const homepage = {
 
   dishes: [
     {
-      price: 110,
-      name: {
-        en: "Chicen Tikka Masala",
-        se: "Kyckling Tikka Masala",
-      },
-      description: {
-        en: "These dishes are roasted in a clay oven in a masala sauce with yoghurt, cheese, butter and nuts",
-        se: "Dessa rätter är rostade i en lerugn i en masalasås med yoghurt, ost, smör och nötter",
-      },
-      source: "/samosa.jpeg",
-    },
-    {
-      price: 125,
-      name: {
-        en: "Mixed Chicken Grill",
-        se: "Blandad kycklinggrill",
-      },
-      description: {
-        en: "Chicken fillet marinated in tandoori, garlic and green chili, grilled in a clay oven and stir-fried fresh vegetables and sauce.",
-        se: "Kycklingfilé marinerad i tandoori, vitlök och grön chili, grillad i lerugn och wokade färska grönsaker och sås",
-      },
-      source: "/mixed-grill.jpg",
-    },
-    {
       price: 115,
       name: {
-        en: "Dal Pumpkin Paneer",
-        se: "Dal Pumpkin Paneer",
+        en: "Samosa Chaat",
+        se: "Samosa Chaat",
       },
       description: {
-        en: "Leaf spinach, homemade cheese with blandale lentils and in a huggable sauce.",
-        se: "Bladspenat, hemgjord ost med blandale linser och i en krambar sås",
+        en: "Crisp pastry pockets served with tamarind and mango mint chutneys.",
+        se: "Krispiga degknyten serverade med tamarind- och mangomintsås.",
       },
-      source: "/chicken-tikka.jpg",
+      source: "/menu/samosa-tamarind-mango-mint.svg",
     },
     {
-      price: null,
+      price: 159,
       name: {
-        en: "Korai",
-        se: "Korai",
+        en: "Thukpa",
+        se: "Thukpa",
       },
       description: {
-        en: "These dishes are roasted in a clay oven in a masala sauce with yoghurt, cheese, butter and nuts",
-        se: "Dessa rätter rostas i en lerugn i en masalasås med yoghurt, ost, smör och nötter",
+        en: "Comforting Himalayan noodle soup with vegetables and aromatics.",
+        se: "Värmande himalayisk nudelsoppa med grönsaker och aromatiska kryddor.",
       },
-      source: "/chicken-korai.jpg",
-    },
-    {
-      price: 120,
-      name: {
-        en: "OUMPH! KORAI",
-        se: "OUMPH! KORAI",
-      },
-      description: {
-        en: "Clay oven grilled soy fillets",
-        se: "Lerugnsgrillade sojafiléer",
-      },
-      source: "/oumph-korai.jpg",
+      source: "/menu/thukpa.svg",
     },
     {
       price: 135,
       name: {
-        en: "Lamb Biryani",
-        se: "Lamm Biryani",
+        en: "Momos",
+        se: "Momos",
       },
       description: {
-        en: "Indian party risotto made from lamb with a lot of good spices and saffron",
-        se: "Indisk festrisotto gjord på lamm med mycket goda kryddor och saffran",
+        en: "Steamed Nepali dumplings filled with spiced vegetables or chicken.",
+        se: "Ångade nepalesiska dumplings fyllda med kryddade grönsaker eller kyckling.",
       },
-      source: "/palak_paneer.jpg",
+      source: "/menu/momos.svg",
+    },
+    {
+      price: 149,
+      name: {
+        en: "Choila",
+        se: "Choila",
+      },
+      description: {
+        en: "Smoky grilled meat tossed with toasted spices, herbs and mustard oil.",
+        se: "Rökt grillat kött med rostade kryddor, örter och senapsolja.",
+      },
+      source: "/menu/choila.svg",
+    },
+    {
+      price: 179,
+      name: {
+        en: "Chicken Timur",
+        se: "Chicken Timur",
+      },
+      description: {
+        en: "Charred chicken seasoned with citrusy timur pepper and fresh coriander.",
+        se: "Grillad kyckling kryddad med citrusdoftande timurpeppar och färsk koriander.",
+      },
+      source: "/menu/chicken-timur.svg",
+    },
+    {
+      price: 169,
+      name: {
+        en: "Chilli Chicken",
+        se: "Chili-kyckling",
+      },
+      description: {
+        en: "Indo-Nepalese style chilli chicken glazed in a spicy soy sauce.",
+        se: "Indisk-nepalesisk chili-kyckling glaserad i kryddig sojasås.",
+      },
+      source: "/menu/chilli-chicken.svg",
+    },
+    {
+      price: 159,
+      name: {
+        en: "Chicken & Scampi Noodles",
+        se: "Nudlar med kyckling och scampi",
+      },
+      description: {
+        en: "Wok-tossed noodles with chicken, scampi and colourful vegetables.",
+        se: "Wokade nudlar med kyckling, scampi och färgglada grönsaker.",
+      },
+      source: "/menu/noodles-chicken-scampi.svg",
+    },
+    {
+      price: 149,
+      name: {
+        en: "Fried Rice",
+        se: "Stekt ris",
+      },
+      description: {
+        en: "Fragrant fried rice folded with seasonal vegetables and egg.",
+        se: "Aromatiskt stekt ris med säsongens grönsaker och ägg.",
+      },
+      source: "/menu/fried-rice.svg",
+    },
+    {
+      price: 189,
+      name: {
+        en: "Grilled Chicken & Pommes",
+        se: "Grillad kyckling med pommes",
+      },
+      description: {
+        en: "Herb grilled chicken served with crisp pommes frites and salad.",
+        se: "Örtgrillad kyckling serverad med krispiga pommes frites och sallad.",
+      },
+      source: "/menu/grilled-chicken-pommes.svg",
+    },
+    {
+      price: 155,
+      name: {
+        en: "Chicken Burger",
+        se: "Kycklingburgare",
+      },
+      description: {
+        en: "Juicy chicken burger layered with pickles, greens and house sauce.",
+        se: "Saftig kycklingburgare med pickles, grönt och husets sås.",
+      },
+      source: "/menu/chicken-burger.svg",
+    },
+    {
+      price: 185,
+      name: {
+        en: "Schnitzel",
+        se: "Schnitzel",
+      },
+      description: {
+        en: "Golden fried schnitzel with lemon, butter and garden greens.",
+        se: "Gyllene friterad schnitzel med citron, smör och gröna blad.",
+      },
+      source: "/menu/schnitzel.svg",
+    },
+    {
+      price: 145,
+      name: {
+        en: "Caesar Salad",
+        se: "Caesarsallad",
+      },
+      description: {
+        en: "Classic Caesar with romaine, parmesan, croutons and creamy dressing.",
+        se: "Klassisk Caesar med romansallad, parmesan, krutonger och krämig dressing.",
+      },
+      source: "/menu/caesar-salad.svg",
+    },
+    {
+      price: 129,
+      name: {
+        en: "Mustang Aaloo",
+        se: "Mustang Aaloo",
+      },
+      description: {
+        en: "Smoked potatoes tempered with Himalayan spices and sesame.",
+        se: "Rökta potatisar smaksatta med himalayiska kryddor och sesam.",
+      },
+      source: "/menu/mustang-aloo.svg",
+    },
+    {
+      price: 189,
+      name: {
+        en: "Chicken Teriyaki",
+        se: "Kyckling Teriyaki",
+      },
+      description: {
+        en: "Glazed teriyaki chicken with sesame, spring onion and steamed rice.",
+        se: "Glaserad teriyakikyckling med sesam, salladslök och ångat ris.",
+      },
+      source: "/menu/chicken-teriyaki.svg",
     },
   ],
 


### PR DESCRIPTION
## Summary
- modernize the homepage menu scroller with illustrated cards and richer dish details
- refresh homepage translations with a new dish lineup and bespoke artwork
- disable the BUDDHA Haga location until launch while defaulting to the active venue

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0c97be63c832f8f5b238878cf7127