### PR TITLE
Update Haga contact numbers and navbar phone link

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -16,11 +16,7 @@ export default function Navbar({ id }: { id: string }) {
 
   const t = router.locale as Language;
 
-  const phone = location
-    ? locations[location].phones.find(
-        (p) => !p.replace(/\s+/g, "").startsWith("07")
-      )
-    : null;
+  const phone = location ? locations[location].phones[0] ?? null : null;
 
   useEffect(() => {
     setLocationModal(!location);

--- a/src/context/LocationContext.tsx
+++ b/src/context/LocationContext.tsx
@@ -35,7 +35,7 @@ const locations: Record<LocationKey, LocationInfo> = {
   haga: {
     name: "Ynglingagatan 9, 113 47 Stockholm",
     shortName: "BUDDHA Haga",
-    phones: ["08-684 271 90", "0760-35 37 99"],
+    phones: ["076-582 82 88", "0760-35 37 99"],
     mapSrc:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4068.038657368876!2d18.04833100611805!3d59.34932516386402!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f9d724ef405ef%3A0xba83e55580836315!2sYnglingagatan%209%2C%20113%2047%20Stockholm!5e0!3m2!1sen!2sse!4v1757644789600!5m2!1sen!2sse",
     isActive: true,


### PR DESCRIPTION
## Summary
- update the Haga location phone numbers to use the latest mobile contacts while keeping Årsta untouched
- ensure the navbar phone icon links to the first phone number of the active location

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d96a826ca4832f81535d30ce716f43