### PR TITLE
Comment out hidden Haga sections

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -19,7 +19,6 @@ export default function Footer() {
     LocationInfo,
   ][];
   const activeLocations = locationEntries.filter(([, info]) => info.isActive);
-  const upcomingLocations = locationEntries.filter(([, info]) => !info.isActive);
 
   const deliveryPartners = [
     { src: "/foodora.svg", alt: "Foodora" },
@@ -154,38 +153,34 @@ export default function Footer() {
                 );
               })}
 
-              {upcomingLocations.map(([key, info]) => {
-                const statusMessage = info.statusMessage?.[locale];
-                const statusLabel =
-                  statusMessage ?? contact.coming_soon_default[locale];
+              {/*
+                Upcoming locations (such as BUDDHA Haga) are hidden until launch.
+                Re-enable the JSX below once the restaurant opens so it appears in
+                the contact list again.
 
-                return (
-                  <article
-                    key={key}
-                    className="relative overflow-hidden rounded-3xl border border-white/20 bg-gradient-to-br from-primary to-primary/70 p-6 text-white shadow-xl"
-                  >
-                    <div className="pointer-events-none absolute -top-10 right-0 h-24 w-24 rounded-full bg-white/10 blur-3xl" />
-                    <div className="pointer-events-none absolute -bottom-6 left-6 h-20 w-20 rounded-full bg-white/10 blur-2xl" />
-                    <div className="relative flex h-full flex-col gap-3">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <h3 className="text-xl font-semibold">{info.shortName}</h3>
-                          <p className="text-sm text-white/80">{info.name}</p>
-                        </div>
-                        <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-white">
-                          {statusLabel}
-                        </span>
+                <article
+                  key="haga"
+                  className="relative overflow-hidden rounded-3xl border border-white/20 bg-gradient-to-br from-primary to-primary/70 p-6 text-white shadow-xl"
+                >
+                  <div className="pointer-events-none absolute -top-10 right-0 h-24 w-24 rounded-full bg-white/10 blur-3xl" />
+                  <div className="pointer-events-none absolute -bottom-6 left-6 h-20 w-20 rounded-full bg-white/10 blur-2xl" />
+                  <div className="relative flex h-full flex-col gap-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-xl font-semibold">{locationData.haga.shortName}</h3>
+                        <p className="text-sm text-white/80">{locationData.haga.name}</p>
                       </div>
-                      <p className="text-sm text-white/80">
-                        {statusMessage ?? contact.coming_soon_description[locale]}
-                      </p>
-                      <p className="text-xs text-white/60">
-                        {contact.coming_soon_follow[locale]}
-                      </p>
+                      <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-white">
+                        {locationData.haga.statusMessage?.[locale] ?? contact.coming_soon_default[locale]}
+                      </span>
                     </div>
-                  </article>
-                );
-              })}
+                    <p className="text-sm text-white/80">
+                      {locationData.haga.statusMessage?.[locale] ?? contact.coming_soon_description[locale]}
+                    </p>
+                    <p className="text-xs text-white/60">{contact.coming_soon_follow[locale]}</p>
+                  </div>
+                </article>
+              */}
             </div>
           </div>
         </div>

--- a/src/context/LocationContext.tsx
+++ b/src/context/LocationContext.tsx
@@ -38,7 +38,7 @@ const locations: Record<LocationKey, LocationInfo> = {
     phones: ["076-582 82 88", "0760-35 37 99"],
     mapSrc:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4068.038657368876!2d18.04833100611805!3d59.34932516386402!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f9d724ef405ef%3A0xba83e55580836315!2sYnglingagatan%209%2C%20113%2047%20Stockholm!5e0!3m2!1sen!2sse!4v1757644789600!5m2!1sen!2sse",
-    isActive: true,
+    isActive: false,
   },
 };
 

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -16,6 +16,7 @@ export default function Contact() {
     LocationKey,
     LocationInfo,
   ][];
+  const activeLocations = locationEntries.filter(([, info]) => info.isActive);
 
   return (
     <main className="flex-1 flex">
@@ -27,89 +28,85 @@ export default function Contact() {
           <h1 className="text-4xl lg:text-5xl font-bold">{contact.title[t]}</h1>
 
           <div className="grid w-full grid-cols-1 gap-8 text-left md:grid-cols-2">
-            {locationEntries.map(([key, info]) => {
-              const isActive = info.isActive;
-              const statusMessage = info.statusMessage?.[t];
-              const statusLabel = statusMessage ?? contact.coming_soon_default[t];
+            {activeLocations.map(([key, info]) => {
               const phoneNumbers = info.phones ?? [];
-
-              if (isActive) {
-                return (
-                  <article
-                    key={key}
-                    className="relative flex h-full flex-col gap-6 rounded-3xl border border-primary/10 bg-white/95 p-8 text-slate-900 shadow-lg transition-shadow duration-300 hover:shadow-xl"
-                  >
-                    <div className="flex flex-col gap-3">
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="flex flex-col">
-                          <h2 className="text-2xl font-semibold text-primary">
-                            {info.shortName}
-                          </h2>
-                          <p className="text-sm font-medium uppercase tracking-wide text-primary/70">
-                            {contact.opening_times[t]}
-                          </p>
-                        </div>
-                        <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
-                          {contact.open_label[t]}
-                        </span>
-                      </div>
-                      <p className="text-base text-slate-600">{info.name}</p>
-                      <div className="space-y-1 text-sm text-slate-700">
-                        <p>{contact.weekdays[t]}</p>
-                        <p>{contact.weekends[t]}</p>
-                      </div>
-                    </div>
-
-                    <div className="rounded-2xl border border-primary/20 bg-primary/5 p-5">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">
-                        {contact.order_call[t]}
-                      </p>
-                      <div className="mt-4 flex flex-col gap-2">
-                        {phoneNumbers.map((phone) => {
-                          const sanitized = phone.replace(/\s+/g, "");
-                          return (
-                            <a
-                              key={sanitized}
-                              href={`tel:${sanitized}`}
-                              className="text-lg font-semibold text-primary transition-colors duration-200 hover:text-primary/80"
-                            >
-                              {phone}
-                            </a>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </article>
-                );
-              }
 
               return (
                 <article
                   key={key}
-                  className="relative overflow-hidden rounded-3xl border border-white/20 bg-gradient-to-br from-primary to-primary/70 p-8 text-white shadow-xl"
+                  className="relative flex h-full flex-col gap-6 rounded-3xl border border-primary/10 bg-white/95 p-8 text-slate-900 shadow-lg transition-shadow duration-300 hover:shadow-xl"
                 >
-                  <div className="pointer-events-none absolute -top-16 right-0 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
-                  <div className="pointer-events-none absolute -bottom-10 left-10 h-24 w-24 rounded-full bg-white/10 blur-2xl" />
-                  <div className="relative flex h-full flex-col gap-4">
+                  <div className="flex flex-col gap-3">
                     <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <h2 className="text-2xl font-semibold">{info.shortName}</h2>
-                        <p className="text-sm text-white/80">{info.name}</p>
+                      <div className="flex flex-col">
+                        <h2 className="text-2xl font-semibold text-primary">
+                          {info.shortName}
+                        </h2>
+                        <p className="text-sm font-medium uppercase tracking-wide text-primary/70">
+                          {contact.opening_times[t]}
+                        </p>
                       </div>
-                      <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
-                        {statusLabel}
+                      <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+                        {contact.open_label[t]}
                       </span>
                     </div>
-                    <p className="text-base text-white/80">
-                      {statusMessage ?? contact.coming_soon_description[t]}
+                    <p className="text-base text-slate-600">{info.name}</p>
+                    <div className="space-y-1 text-sm text-slate-700">
+                      <p>{contact.weekdays[t]}</p>
+                      <p>{contact.weekends[t]}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-primary/20 bg-primary/5 p-5">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+                      {contact.order_call[t]}
                     </p>
-                    <p className="text-sm text-white/60">
-                      {contact.coming_soon_follow[t]}
-                    </p>
+                    <div className="mt-4 flex flex-col gap-2">
+                      {phoneNumbers.map((phone) => {
+                        const sanitized = phone.replace(/\s+/g, "");
+                        return (
+                          <a
+                            key={sanitized}
+                            href={`tel:${sanitized}`}
+                            className="text-lg font-semibold text-primary transition-colors duration-200 hover:text-primary/80"
+                          >
+                            {phone}
+                          </a>
+                        );
+                      })}
+                    </div>
                   </div>
                 </article>
               );
             })}
+            {/*
+              Temporarily hide the BUDDHA Haga card until the restaurant opens.
+              Restore the JSX below when the location launches so the contact
+              details reappear alongside other active restaurants.
+
+              <article
+                key="haga"
+                className="relative overflow-hidden rounded-3xl border border-white/20 bg-gradient-to-br from-primary to-primary/70 p-8 text-white shadow-xl"
+              >
+                <div className="pointer-events-none absolute -top-16 right-0 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+                <div className="pointer-events-none absolute -bottom-10 left-10 h-24 w-24 rounded-full bg-white/10 blur-2xl" />
+                <div className="relative flex h-full flex-col gap-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h2 className="text-2xl font-semibold">{locationData.haga.shortName}</h2>
+                      <p className="text-sm text-white/80">{locationData.haga.name}</p>
+                    </div>
+                    <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                      {locationData.haga.statusMessage?.[t] ?? contact.coming_soon_default[t]}
+                    </span>
+                  </div>
+                  <p className="text-base text-white/80">
+                    {locationData.haga.statusMessage?.[t] ?? contact.coming_soon_description[t]}
+                  </p>
+                  <p className="text-sm text-white/60">{contact.coming_soon_follow[t]}</p>
+                </div>
+              </article>
+            */}
           </div>
 
           <div className="flex items-center justify-center gap-6 mt-12">


### PR DESCRIPTION
## Summary
- preserve the original Haga contact card on the contact page inside a JSX comment with instructions for restoring it later
- keep the footer's Haga contact markup commented out so it can be re-enabled when the location opens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e15512fbc0832f986462c931f18b41